### PR TITLE
Force Backbone to validate server responses

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,6 @@
         <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/bootstrap-theme.css">
-        <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->
         <link href='http://fonts.googleapis.com/css?family=Lato:100,300,400,700,900' rel='stylesheet' type='text/css'>
         <!-- build:js scripts/vendor/modernizr.js -->

--- a/app/scripts/collections/proposals.js
+++ b/app/scripts/collections/proposals.js
@@ -1,4 +1,4 @@
-/*global Stem, Backbone*/
+/*global Stem, Backbone, _*/
 
 /*
  * Backbone collection for a set of proposals from DonorsChoose.org.
@@ -162,6 +162,27 @@ Stem.Collections = Stem.Collections || {};
                 (this.options.keywords ? ('&' + 'keywords="' + encodeURIComponent(this.options.keywords) + '"') : '') +
                 (this.options.maxSize  ? ('&' + 'max=' + this.options.maxSize) : '') +
                 (this.options.sortBy   ? ('&' + 'sortBy=' + this.options.sortBy) : '');
+        },
+
+        // When fetching a collection from the server, Backbone
+        // does not, by default, validate the models in the returned
+        // response (since it assumes the server is always valid).
+        // We, however, use validation to filter out models that aren't
+        // appropriate for our application. For example we use
+        // validation to remove proposals that are for `"adult"`
+        // classes since those don't fit with a K-12 incubator.
+        // To force model validation, we override the standard
+        // `fetch` method.
+
+        fetch: function(options) {
+
+            // Make sure that `validate` is true in the
+            // options passed to the standard `fetch` method.
+
+            return Backbone.Collection.prototype.fetch.call(
+                this,
+                _({}).extend(options, {validate: true})
+            );
         },
 
         // Since DonorsChoose doesn't follow Rails conventions, we have

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -14,7 +14,7 @@ window.Stem = {
         // Stub/demo code for now
         var proposals = new Stem.Collections.Proposals([], {maxSize: 4});
         proposals.fetch({reset: true});
-         var view = new Stem.Views.ProposalsAsHighlights({collection: proposals});
+        var view = new Stem.Views.ProposalsAsHighlights({collection: proposals});
         view.render();
         $('#crowdfunding').append(view.el);
 

--- a/app/scripts/views/proposalAsHighlight.js
+++ b/app/scripts/views/proposalAsHighlight.js
@@ -35,7 +35,7 @@ Stem.Views = Stem.Views || {};
 
         render: function () {
             this.$el.html(this.template(this.model.toJSON()));
-            // return `this` for chaining
+            // Return `this` for chaining.
             return this;
         }
 

--- a/app/scripts/views/proposalsAsHighlights.js
+++ b/app/scripts/views/proposalsAsHighlights.js
@@ -98,7 +98,7 @@ Stem.Views = Stem.Views || {};
 
             }, this);
 
-            // return `this` for chaining
+            // Return `this` for chaining.
 
             return this;
         }


### PR DESCRIPTION
By default, Backbone assumes that server responses are always correct, and it does not validate them. We're relying on validation, however, to filter out returned objects that aren't appropriate for the site. For example, DonorsChoice allows proposals to be created for adult education programs, which don't really fit with a K-12 incubator. We should ensure that validation is applied when collections are fetched.
