### PR TITLE
Asynchronously load fonts

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,6 +6,10 @@
         <title>Georgia K-12 STEM Incubator</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
+        <!-- ========== Custom Fonts from CDNs ========== -->
+        <link href='http://fonts.googleapis.com/css?family=Raleway:400,300,600' rel='stylesheet' type='text/css'>
+        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+
         <!-- ========== Third Party Style Sheets ========== -->
         <!-- build:css styles/vendor.css -->
         <link rel="stylesheet" href="bower_components/normalize.css/normalize.css">

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1,6 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Raleway:400,300,600);
-/* `@import` statements have to preceed all CSS statements, even comments. */
-/*csslint adjoining-classes:false, box-sizing:false, font-sizes:false, qualified-headings:false, unique-headings:false, import:false */
+/*csslint adjoining-classes:false, box-sizing:false, font-sizes:false, qualified-headings:false, unique-headings:false */
 
 
 /**

--- a/app/styles/styleguide.css
+++ b/app/styles/styleguide.css
@@ -1,3 +1,5 @@
+@import url(http://fonts.googleapis.com/css?family=Raleway:400,300,600);
+/* `@import` statements have to preceed all CSS statements, even comments. */
 /*csslint adjoining-classes:false, box-sizing:false, font-sizes:false, qualified-headings:false, unique-headings:false, import:false, fallback-colors:false, outline-none:false, duplicate-properties:false */
 
 /**


### PR DESCRIPTION
Currently custom fonts are loaded via `@import` statements in the CSS files. This can block rendering. Better to move it into `<link>` tags (but still preserve custom fonts for style guides).
