### PR TITLE
Move child view instantiation for partnersAsDiscovery and adminsAsDis…

### DIFF
--- a/app/scripts/views/adminsAsDiscovery.js
+++ b/app/scripts/views/adminsAsDiscovery.js
@@ -16,20 +16,6 @@ Stem.Views = Stem.Views || {};
         id: 'admins',
 
         initialize: function () {
-
-            // Create the child views.
-
-            this.certificationsMap = new Stem.Views.PoisAsMap({
-                el: $('#admins-certifications-map'),
-                collection: this.model.get('certificationPois'),
-                tintUrl: 'images/theme-2-background.png'
-            });
-
-            this.spotlightList = new Stem.Views.OaeAsSpotlightList({
-                el: $('#admins-spotlights'),
-                collection: this.model.get('spotlights')
-            });
-
         },
 
         render: function () {
@@ -59,10 +45,18 @@ Stem.Views = Stem.Views || {};
             this.$el.attr('aria-labelledby', headingId);
             this.$el.find('h3').attr('id', headingId);
 
-            // Render all the child views.
+            // Create and Render all child views.
 
-            this.certificationsMap.render();
-            this.spotlightList.render();
+            this.certificationsMap = new Stem.Views.PoisAsMap({
+                el: this.$el.find('#admins-certifications-map'),
+                collection: this.model.get('certificationPois'),
+                tintUrl: 'images/theme-2-background.png'
+            }).render();
+
+            this.spotlightList = new Stem.Views.OaeAsSpotlightList({
+                el: this.$el.find('#admins-spotlights'),
+                collection: this.model.get('spotlights')
+            }).render();
 
             // Go ahead and show the map since it's
             // initially visible on tablets and

--- a/app/scripts/views/partnersAsDiscovery.js
+++ b/app/scripts/views/partnersAsDiscovery.js
@@ -60,30 +60,6 @@ Stem.Views = Stem.Views || {};
                 title:  'I’m looking for'
             });
 
-            // Create the child views.
-
-            this.mapFilter = new Stem.Views.TagSetAsInlineCheckboxGroup({
-                el: $('#partners-organizations-filter'),
-                model: this.tagSet
-            });
-
-            this.organizationsMap = new Stem.Views.PoisAsMap({
-                el: $('#partners-organizations-map'),
-                collection: this.model.get('organizationPois'),
-                tintUrl: 'images/theme-3-background.png'
-            });
-
-            this.proposalsMap = new Stem.Views.PoisAsMap({
-                el: $('#partners-donorschoose-map'),
-                collection: this.model.get('proposalPois'),
-                tintUrl: 'images/theme-3-background.png'
-            });
-
-            this.partnershipsList = new Stem.Views.OaeAsSpotlightList({
-                el: $('#partners-spotlights'),
-                collection: this.model.get('partnerships')
-            });
-
         },
 
         render: function () {
@@ -113,12 +89,29 @@ Stem.Views = Stem.Views || {};
             this.$el.attr('aria-labelledby', headingId);
             this.$el.find('h3').attr('id', headingId);
 
-            // Render all the child views.
+            // Create and Render all child views.
 
-            this.mapFilter.render();
-            this.proposalsMap.render();
-            this.organizationsMap.render();
-            this.partnershipsList.render();
+            this.mapFilter = new Stem.Views.TagSetAsInlineCheckboxGroup({
+                el: this.$el.find('#partners-organizations-filter'),
+                model: this.tagSet
+            }).render();
+
+            this.organizationsMap = new Stem.Views.PoisAsMap({
+                el: this.$el.find('#partners-organizations-map'),
+                collection: this.model.get('organizationPois'),
+                tintUrl: 'images/theme-3-background.png'
+            }).render();
+
+            this.proposalsMap = new Stem.Views.PoisAsMap({
+                el: this.$el.find('#partners-donorschoose-map'),
+                collection: this.model.get('proposalPois'),
+                tintUrl: 'images/theme-3-background.png'
+            }).render();
+
+            this.partnershipsList = new Stem.Views.OaeAsSpotlightList({
+                el: this.$el.find('#partners-spotlights'),
+                collection: this.model.get('partnerships')
+            }).render();
 
             this.listenTo(this.tagSet.get('tags'), 'change', this.updateFilters);
 


### PR DESCRIPTION
Sorry for the misunderstanding on issue #53 . I didn't properly explain the problem I was having. The problem occurs when the HTML articles for `partners` and `admins` are empty. The views  `AdminsAsDiscovery` or `PartnersAsDiscovery` are unable to render their content properly since they attempt to instantiate child views before actually templating the parent view (specifically, they attempt this instantiation in the `initialize` function). Of course, this can be replicated not just in testing with empty scaffold elements provided to the view, but on a local site by using `grunt build` with an `index.html` whose article elements are empty.

This pull request simply moves the instantiation to after the view is templated, and changes the selector to specifically look inside the parent element (not doing this also causes issues, which is very weird). This way, the full discovery views can be generated even if the scaffolding for the view initially is empty.
